### PR TITLE
Show/hide asset checkboxes. Allow word search.

### DIFF
--- a/client/src/components/AssetFilterUpdate.js
+++ b/client/src/components/AssetFilterUpdate.js
@@ -25,6 +25,7 @@ const styles = {
 class AssetFilterUpdate extends PureComponent {
   state = {
     isFilterListVisible: false,
+    isAssetTypeCheckboxesHidden: true,
   }
   render() {
     const { classes } = this.props;
@@ -40,6 +41,16 @@ class AssetFilterUpdate extends PureComponent {
             <IconButton 
               className={classes.iconButton}
               aria-label="Menu"
+              onClick={() => {
+                console.log('Iconbutton clicked')
+                if (this.state.isAssetTypeCheckboxesHidden) {
+                  this.setState({isAssetTypeCheckboxesHidden: false})
+                  console.log('ishidden = false')
+                } else {
+                  this.setState({isAssetTypeCheckboxesHidden: true})
+                  console.log('ishidden = true')
+                }
+              }}
               >
               <MenuIcon />
             </IconButton>
@@ -58,6 +69,9 @@ class AssetFilterUpdate extends PureComponent {
               <SearchIcon />
             </IconButton>
           </div>
+          {!this.state.isAssetTypeCheckboxesHidden && <AssetTypeCheckboxes 
+            selectedAssetTypeIds={selectedAssetTypeIds}
+            onAssetTypeClick={onAssetTypeClick} />}
           {/* <AssetTypeCheckboxes 
             selectedAssetTypeIds={selectedAssetTypeIds}
             onAssetTypeClick={onAssetTypeClick} /> */}

--- a/client/src/selectors/index.js
+++ b/client/src/selectors/index.js
@@ -60,10 +60,13 @@ export const getVisibleAssets = createSelector([
   searchTerm,
 ) => {
   console.log(searchTerm)
+  if (searchTerm === 'line') {
+    debugger
+  }
   return (selectedAssetIds.isEmpty() ? sortedAssetIds : selectedAssetIds)
   .map(assetId => assetById.get(assetId))
   .filter(asset => selectedAssetTypeIds.includes(asset.get('typeId')))
-  .filter(asset => asset.get('name').includes(searchTerm))
+  .filter(asset => asset.get('name').toLowerCase().includes(searchTerm.toLowerCase()))
   .slice(0, MAXIMUM_LIST_LENGTH)
 })
 
@@ -207,7 +210,7 @@ export const getMapSources = createSelector(
       assetId,
     ) => {
       const asset = assetById.get(assetId)
-      const assetTypeId = asset.get('typeId')
+      const assetTypeId = asset.get('t ypeId')
       // const featureColor = {}[asset[featureColorAttribute]]
       let featureSize
 


### PR DESCRIPTION
Show/hide asset checkboxes on clicking icon button containing menu icon (to the left of search box). Allow word search within the assets that belong to the types of assets selected with the asset checkboxes.