### PR TITLE
Add best visualization at moment for data thinking in mobile

### DIFF
--- a/src/components/App.js
+++ b/src/components/App.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import React, { useState, useEffect } from 'react'
 import AssetsMap from './AssetsMap'
 import SketchButton from './SketchButton'
 import SketchModeToolbar from './SketchModeToolbar'
@@ -20,7 +20,7 @@ import {
   DARK_MAP_STYLE,
   STREETS_MAP_STYLE,
   SATELLITE_STREETS_MAP_STYLE,
-  BASE_MAP_STYLE_NAME,
+  BASE_MAP_STYLE_NAME, SPEC,
 } from '../constants'
 import {
   getById,
@@ -59,7 +59,18 @@ export default function App() {
   const [selectedFeatureIndexes, setSelectedFeatureIndexes] = useState([])
   const [focusingAssetId, setFocusingAssetId] = useState()
   const [assetById, setAssetById] = useState(getById(ASSETS, {}))
+  const [spec, setSpec] = useState({})
   const [mapStyle, setMapStyle] = useState(BASE_MAP_STYLE_NAME)
+
+  useEffect(() => {
+    fetch('/assets.json').then(async (res) => {
+      let data = await res.json()
+      console.log(data)
+      setSpec(data.spec);
+      setAssetById(getById(data.assets, {}));
+    });
+
+  }, [])
 
   const _toggleIsSketching = () => {
     setIsSketching(!isSketching)
@@ -93,6 +104,7 @@ export default function App() {
         sketchingEditType={sketchingEditType}
         selectedFeatureIndexes={selectedFeatureIndexes}
         assetById={assetById}
+        spec={spec}
         setGeoJson={setGeoJson}
         setIsWithDetails={setIsWithDetails}
         setAssetById={setAssetById}

--- a/src/components/AssetsMap.js
+++ b/src/components/AssetsMap.js
@@ -32,6 +32,7 @@ export default function AssetsMap(props) {
     sketchingEditType,
     selectedFeatureIndexes,
     assetById,
+    spec,
     // setIsWithDetails,
     geoJson,
     setHistory,
@@ -234,6 +235,10 @@ export default function AssetsMap(props) {
     const geometryCoordinates = geometry.coordinates
     const assetId = f.properties.id
     const asset = assetById[assetId]
+    if (!asset) {
+      continue
+    }
+
     const busByIndex = asset.busByIndex
 
     if (!busByIndex) {

--- a/src/components/DetailsWindow.js
+++ b/src/components/DetailsWindow.js
@@ -6,8 +6,12 @@ import Paper from '@material-ui/core/Paper'
 import Typography from '@material-ui/core/Typography'
 import Card from '@material-ui/core/Card'
 import TextField from '@material-ui/core/TextField';
+import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
 import CloseButton from './CloseButton'
 import DeleteButton from './DeleteButton'
+import {ExpansionPanel} from "@material-ui/core";
+import ExpansionPanelSummary from "@material-ui/core/ExpansionPanelSummary";
+import ExpansionPanelDetails from "@material-ui/core/ExpansionPanelDetails";
 
 const useStyles = makeStyles(theme => ({
   root: {
@@ -31,6 +35,18 @@ const useStyles = makeStyles(theme => ({
   }, 
   input: {
     width: '100%'
+  },
+  mimic: {
+    border: 'none',
+    boxShadow: 'none',
+  },
+  noPadding: {
+    padding: 0
+  },
+  vertical: {
+    display: 'flex',
+    flexDirection: 'column',
+    padding: 0
   }
 }))
 
@@ -64,17 +80,117 @@ function DetailsWindow(props) {
     const fields = []
     for (let key in focusingAsset) {
       if (focusingAsset.hasOwnProperty(key)){
-        fields.push(
-          <TextField
-            className={classes.input}
-            name={key}
-            key={focusingAsset.id + "_" + key}
-            label={key}
-            value={focusingAsset[key]}
-            disabled={key === 'id' || key === 'type'}
-            onChange={ _onChange }
-          />
-        ) 
+        if (key == 'attributes') {
+          fields.push(
+            <ExpansionPanel className={classes.mimic}>
+              <ExpansionPanelSummary
+                className={classes.noPadding}
+                expandIcon={<ExpandMoreIcon />}
+                aria-controls="panel1a-content"
+                id="panel1a-header">
+                <Typography>Attributes</Typography>
+              </ExpansionPanelSummary>
+              <ExpansionPanelDetails className={classes.vertical}>
+                {
+                  Object.keys(focusingAsset.attributes).map((key) => <TextField
+                    className={classes.input}
+                    name={key}
+                    key={focusingAsset.id + "_attribute " + key}
+                    label={key}
+                    value={focusingAsset.attributes[key]}
+                    disabled={key === 'id' || key === 'type'}
+                  />)
+                }
+              </ExpansionPanelDetails>
+            </ExpansionPanel>
+            )
+        } else if (key == 'busByIndex') {
+          fields.push(
+            <ExpansionPanel className={classes.mimic}>
+              <ExpansionPanelSummary
+                className={classes.noPadding}
+                expandIcon={<ExpandMoreIcon />}
+                aria-controls='panel-buses-content'
+                id='panel-buses-header'>
+                <Typography>Buses</Typography>
+              </ExpansionPanelSummary>
+              <ExpansionPanelDetails className={classes.vertical}>
+              { Object.keys(focusingAsset.busByIndex).map((key) => <>
+                  <ExpansionPanel className={classes.mimic}>
+                    <ExpansionPanelSummary
+                      expandIcon={<ExpandMoreIcon />}
+                      aria-controls={`panel${key}-content`}
+                      id={`panel${key}-header`}>
+                      <Typography>Bus {key}</Typography>
+                    </ExpansionPanelSummary>
+                    <ExpansionPanelDetails className={classes.vertical}>
+                      {
+                        Object.keys(focusingAsset.busByIndex[key].attributes).map((key) => <TextField
+                          className={classes.input}
+                          name={key}
+                          key={focusingAsset.id + "_attribute " + key}
+                          label={key}
+                          value={focusingAsset.attributes[key]}
+                          disabled={key === 'id' || key === 'type'}
+                        />) || []
+                      }
+                    </ExpansionPanelDetails>
+                  </ExpansionPanel>
+                </>
+              )}
+              </ExpansionPanelDetails>
+            </ExpansionPanel>
+          )
+        } else if (key == 'electricalConnections') {
+          fields.push(
+            <ExpansionPanel className={classes.mimic}>
+              <ExpansionPanelSummary
+                className={classes.noPadding}
+                expandIcon={<ExpandMoreIcon />}
+                aria-controls='panel-buses-content'
+                id='panel-buses-header'>
+                <Typography>Electrical Connections</Typography>
+              </ExpansionPanelSummary>
+              <ExpansionPanelDetails className={classes.vertical}>
+                { focusingAsset.electricalConnections.map((conn) => <>
+                    <ExpansionPanel className={classes.mimic}>
+                      <ExpansionPanelSummary
+                        expandIcon={<ExpandMoreIcon />}
+                        aria-controls={`panel${conn.asset_id + conn.bus_id}-content`}
+                        id={`panel${conn.asset_id + conn.bus_id}-header`}>
+                        <Typography>Element {conn.asset_id} - Bus {conn.bus_id}</Typography>
+                      </ExpansionPanelSummary>
+                      <ExpansionPanelDetails className={classes.vertical}>
+                        {
+                          Object.keys(conn.attributes).map((key) => <TextField
+                            className={classes.input}
+                            name={key}
+                            key={focusingAsset.id + "_attribute " + key}
+                            label={key}
+                            value={JSON.stringify(conn.attributes[key])}
+                            disabled={key === 'id' || key === 'type'}
+                          />) || []
+                        }
+                      </ExpansionPanelDetails>
+                    </ExpansionPanel>
+                  </>
+                )}
+              </ExpansionPanelDetails>
+            </ExpansionPanel>
+          )
+        } else {
+          fields.push(
+            <TextField
+              className={classes.input}
+              name={key}
+              key={focusingAsset.id + "_" + key}
+              label={key}
+              value={focusingAsset[key]}
+              disabled={key === 'id' || key === 'type'}
+              onChange={ _onChange }
+            />
+          )
+        }
       }
     }
     return fields
@@ -91,21 +207,7 @@ function DetailsWindow(props) {
       <>
         <Typography>{focusingAsset.name}</Typography>
         {/* <Typography>{focusingAsset.type}</Typography> */}
-      {focusingAsset.electricalConnections &&
-      <div className={classes.section}>
-          <Typography><i>Electrical Connections</i></Typography>
-
-        {Object.keys(focusingAsset.electricalConnections).map(k => {
-          const connectedAsset = assetById[k]
-          return (
-            <Card className={classes.card}>
-              {connectedAsset.name}
-            </Card>
-          )
-        }
-        )}
-      </div>
-      }
+      
       <form noValidate autoComplete="off" className={classes.form}>
         {
           getFields()

--- a/src/constants.js
+++ b/src/constants.js
@@ -88,7 +88,7 @@ export const GEOJSON = {
   }, {
     type: 'Feature',
     properties: {
-      id: 5,
+      id: "632-645",
       type: 'l',
     },
     geometry: {
@@ -103,7 +103,7 @@ export const GEOJSON = {
   }, {
     type: 'Feature',
     properties: {
-      id: 6,
+      id: "632-633",
       type: 'l',
     },
     geometry: {
@@ -116,7 +116,7 @@ export const GEOJSON = {
   }, {
     type: 'Feature',
     properties: {
-      id: 7,
+      id: "645-646",
       type: 'l',
     },
     geometry: {


### PR DESCRIPTION
Adding expandable sections for well-known asset attributes:
## When an asset is selected, we can see its sections:
![Asset Tracker (1)](https://user-images.githubusercontent.com/660973/71579544-b2341080-2ac2-11ea-98ba-ac4f2368d398.png)

## DIsplaying the attributes corresponding to selected asset
![Asset Tracker (2)](https://user-images.githubusercontent.com/660973/71579541-b19b7a00-2ac2-11ea-9b92-288e529f20cc.png)

## List of buses which this element is connected
![Asset Tracker (3)](https://user-images.githubusercontent.com/660973/71579543-b19b7a00-2ac2-11ea-9081-f891e4a3e432.png)

## List the electrical connections and its attributes
![Asset Tracker (4)](https://user-images.githubusercontent.com/660973/71579540-b19b7a00-2ac2-11ea-9ab9-551c67f57b2b.png)

This changes required update the server to update the assets: https://github.com/AmericanPublicPowerAssociation/asset-tracker-server/pull/24